### PR TITLE
Add patches to disable write caching

### DIFF
--- a/skeleton/.system/miyoomini/paks/MinUI.pak/launch.sh
+++ b/skeleton/.system/miyoomini/paks/MinUI.pak/launch.sh
@@ -34,6 +34,13 @@ killall keymon
 export LD_LIBRARY_PATH="$SYSTEM_PATH/lib:$LD_LIBRARY_PATH"
 export PATH="$SYSTEM_PATH/bin:$PATH"
 
+# EITHER mount shared data without a write cache (bad performance)
+#mount --bind $SHARED_USERDATA_PATH $SHARED_USERDATA_PATH >> $LOGS_PATH/MinUI.txt 2>&1
+#mount -o remount,sync $SHARED_USERDATA_PATH >> $LOGS_PATH/MinUI.txt 2>&1
+
+# OR disable write caching for the whole sd card (even worse performance)
+#mount -o remount,sync $SDCARD_PATH >> $LOGS_PATH/MinUI.txt 2>&1
+
 lumon & # adjust lcd luma and saturation
 
 CHARGING=`cat /sys/devices/gpiochip0/gpio/gpio59/value`


### PR DESCRIPTION
The default Miyoo Mini kernel mounts the SD card with a write cache enabled. This causes problems when the SD card filesystem dismounts unexpectedly (eg. during a crash) because the cache is not reliably flushed. We lose files, and the SD card gradually accumulates VFAT directory corruption, leading to non-deterministic failures later.

There are two ways to fix this:

1. Mount the SD card with the write cache disabled. This causes a substantial performance hit, because Union writes to files in response to UI events, and launching an emulator while waiting for writes to complete is very slow.
2. Disable the write cache for just shared user data directory, leaving it enabled for the rest of the SD card. This improves performance by allowing inessential files (eg. logs, swap, etc) to be cached, while still preserving important files and (to a lesser extent) the VFAT directory.

A commented-out patch is provided to further test both of these options. Uncomment the appropriate lines to enable either behaviour. They are (probably?) mutually exclusive, so only enable one at a time. In my opinion, neither option performs acceptably, but #2 is slightly better.

Unfortunately, in either case the update to the Recently Played list still causes a perceptible delay. My suggestion is to implement #2 above, then modify Union to update the list when returning from the emulator, not while launching it. This would reduce the disk contention and hide the uncached write. I haven't provided a patch to change the Union behaviour (sorry!).